### PR TITLE
feat: retire tokens with impact certificate generation

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -21,6 +21,7 @@ const ImpactCharts = dynamic(
   { ssr: false }
 );
 import { RetireTokensButton } from '@/components/dashboard/retire-tokens-button';
+import { RetirementModal } from '@/components/dashboard/retirement-modal';
 import { WalletPrompt } from '@/components/dashboard/wallet-prompt';
 import type { DashboardData } from '@/types/dashboard';
 
@@ -30,6 +31,7 @@ export default function DashboardPage() {
   const [walletConnected, setWalletConnected] = useState(false);
   const [publicKey, setPublicKey] = useState<string | null>(null);
   const [showWalletPrompt, setShowWalletPrompt] = useState(false);
+  const [showRetireModal, setShowRetireModal] = useState(false);
   const [data, setData] = useState<DashboardData>({
     tokenBalance: '0',
     co2Offset: '0',
@@ -122,15 +124,15 @@ export default function DashboardPage() {
 
   const handleRetireTokens = async (amount: number) => {
     if (!publicKey) return;
+    // Opened via modal now — kept for legacy RetireTokensButton compatibility
+    setShowRetireModal(true);
+    void amount;
+  };
 
-    try {
-      // TODO: Implement token retirement logic (placeholder)
-      console.log('Retiring tokens:', amount, 'for', publicKey);
-      showToast(`Retired ${amount} tokens (simulated)`, 'success');
-    } catch (err) {
-      console.error('Error retiring tokens:', err);
-      showToast('Failed to retire tokens. Please try again.', 'error');
-    }
+  const handleRetireSuccess = (txHash: string, amount: number) => {
+    showToast(`Successfully retired ${amount} CCT tokens`, 'success');
+    if (publicKey) loadDashboardData(publicKey);
+    void txHash;
   };
 
   const handleWalletConnect = (publicKey: string) => {
@@ -281,11 +283,24 @@ export default function DashboardPage() {
 
         {/* Retire Tokens Button */}
         <div className="mb-8 flex justify-center md:justify-start">
-          <RetireTokensButton
-            onRetire={handleRetireTokens}
+          <button
+            onClick={() => setShowRetireModal(true)}
             disabled={isLoading || parseFloat(data.tokenBalance) === 0}
-          />
+            className="px-6 py-3 bg-gradient-to-r from-green-600 to-green-700 text-white font-semibold rounded-lg shadow-md hover:from-green-700 hover:to-green-800 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+          >
+            🌿 Retire Tokens
+          </button>
         </div>
+
+        {/* Retirement Modal */}
+        {showRetireModal && publicKey && (
+          <RetirementModal
+            publicKey={publicKey}
+            tokenBalance={data.tokenBalance}
+            onClose={() => setShowRetireModal(false)}
+            onSuccess={handleRetireSuccess}
+          />
+        )}
 
         {/* Charts */}
         <div className="mb-8">

--- a/lib/stellar-integration.ts
+++ b/lib/stellar-integration.ts
@@ -7,6 +7,7 @@ import {
   Transaction,
   BASE_FEE,
   StrKey,
+  Memo,
 } from '@stellar/stellar-sdk';
 import {
   isConnected,
@@ -390,6 +391,43 @@ export async function cancelListing(
   }
 }
 
+/**
+ * Retire (burn) CCT tokens by sending them to the issuer account.
+ * On Stellar, burning is achieved by sending the asset back to its issuer.
+ * The transaction memo is set to "retirement" so it is picked up by the
+ * transaction-history parser as a Retirement event.
+ */
+export async function retireTokens(
+  userPublicKey: string,
+  amount: number
+): Promise<{ hash: string }> {
+  const server = new Horizon.Server(HORIZON_TESTNET_URL);
+  const account = await server.loadAccount(userPublicKey);
+
+  const cct = new Asset('CCT', CCT_ISSUER);
+
+  const transaction = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: CCT_ISSUER,
+        asset: cct,
+        amount: amount.toFixed(7),
+      })
+    )
+    .addMemo(Memo.text('retirement'))
+    .setTimeout(30)
+    .build();
+
+  const signedXDR = await signTransaction(transaction.toXDR());
+  if (!signedXDR) throw new Error('Failed to sign retirement transaction');
+
+  const result = await submitTransaction(signedXDR);
+  return { hash: result.hash };
+}
+
 export async function retryOperation<T>(
   operation: () => Promise<T>,
   maxRetries = 3,
@@ -445,6 +483,7 @@ const stellarIntegration = {
   buyTokens,
   fetchUserListings,
   cancelListing,
+  retireTokens,
   retryOperation,
   waitForTransactionConfirmation,
 };

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
   },
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",
-
     "@stellar/stellar-sdk": "^14.4.3",
     "clsx": "^2.1.1",
     "framer-motion": "^12.28.1",
+    "html2canvas": "^1.4.1",
     "lucide-react": "^0.562.0",
     "next": "15.3.1",
+    "qrcode": "^1.5.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.4.0"
@@ -24,6 +25,7 @@
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/qrcode": "^1.5.5",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",


### PR DESCRIPTION
- Add retireTokens() to stellar-integration.ts (burns CCT by sending to issuer with 'retirement' memo)
- Add RetirementModal component with 4-step flow: input -> confirm -> processing -> success
- Success screen shows tx hash, Stellar explorer link, downloadable PNG certificate
- Certificate includes: user address, amount, CO2 offset, date, tx hash, QR code
- Social share buttons for Twitter/X and LinkedIn
- Dashboard wired up with modal trigger replacing inline retire button
- html2canvas + qrcode loaded dynamically (graceful fallback if not installed)
this pr closes #21 